### PR TITLE
Fix broken case.

### DIFF
--- a/workshop/SUMMARY.md
+++ b/workshop/SUMMARY.md
@@ -10,7 +10,7 @@
 * [Data Connection and Virtualization for Admins](db-connection-and-virtualization/README.md)
 * [Import Data to Project](addData/README.md)
 * [Data Visualization with Data Refinery](data-visualization-and-refinery/README.md)
-* [Machine Learning with Jupyter](machine-learning-in-jupyter-notebook/README.md)
+* [Machine Learning with Jupyter](machine-learning-in-Jupyter-notebook/README.md)
 * [Monitoring models with OpenScale](monitoring-models-with-openscale-gui/README.md)
 
 


### PR DESCRIPTION
Linux is case sensitive, so the name of the directory matters, but
git is having this problem:

```bash
 $ git mv machine-learning-in-Jupyter-notebook machine-learning-in-jupyter-notebook
fatal: renaming 'workshop/machine-learning-in-Jupyter-notebook' failed: Invalid argument
```
In order to make the link work, change the case in SUMMARY.md. It would
be better to rename the directory, but git doesn't like that.